### PR TITLE
Update mlflow builder to also build the trainer image

### DIFF
--- a/images/builders/mlflow/Dockerfile
+++ b/images/builders/mlflow/Dockerfile
@@ -1,11 +1,26 @@
+FROM gcr.io/kaniko-project/executor:v1.6.0 AS kaniko
 
-FROM alpine
+FROM alpine:latest
 
-ENV FUSEML_FILES=/fuseml-dockerfiles
+COPY --from=kaniko /kaniko /kaniko
+ENV HOME /root
+ENV USER root
+ENV PATH $PATH:/usr/local/bin:/kaniko
+ENV DOCKER_CONFIG /kaniko/.docker/
 
-COPY mlflow ${FUSEML_FILES}/
+WORKDIR /workspace
 
+RUN apk add --no-cache ca-certificates jq curl unzip
+
+RUN curl -LO https://github.com/mayflower/docker-ls/releases/latest/download/docker-ls-linux-amd64.zip \
+  && unzip docker-ls-linux-amd64.zip -d /usr/local/bin \
+  && rm docker-ls-linux-amd64.zip \
+  && apk del curl unzip \
+  && rm -rf /var/spool
+
+ENV MLFLOW_DOCKERFILE=/fuseml-mlflow
+
+COPY mlflow/ ${MLFLOW_DOCKERFILE}/
 COPY run.sh /usr/local/bin/run
 
-ENTRYPOINT [ "run" ]
-	
+ENTRYPOINT ["run"]

--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -4,14 +4,14 @@ RUN apk add --no-cache bash git
 
 COPY conda.yaml /env/
 
-RUN env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
-   printf ". /opt/conda/etc/profile.d/conda.sh\nconda activate ${env}" > /root/.bashrc
-
 ENV PIP_NO_CACHE_DIR=off
 ENV BASH_ENV /root/.bashrc
 
-RUN conda update conda && \
+RUN env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
+  printf ". /opt/conda/etc/profile.d/conda.sh\nconda activate ${env}" > /root/.bashrc && \
+  conda update conda && \
   conda env create -f /env/conda.yaml && \
+  conda install -n ${env} boto3 && \
   find /opt/conda/ -follow -type f -name '*.a' -delete && \
   find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
   conda clean -afy

--- a/images/builders/mlflow/run.sh
+++ b/images/builders/mlflow/run.sh
@@ -1,4 +1,57 @@
 #!/bin/sh
 
-mkdir -p .fuseml
-cp -rv ${FUSEML_FILES}/* .fuseml/ | awk '/Dockerfile/ {print $3}' | sed -e "s/[\r\n']//g"
+set -o pipefail
+
+# generates a checksum based on the contents of a conda.yaml file
+get_tag() {
+    file=${1:-"conda.yaml"}
+    dep_provider=""
+
+    while IFS= read -r line; do
+        name=$(echo ${line} | sed 's/ *- //g')
+        case $line in
+            '  - '*':')
+                dep_provider=$(printf '%s' "${name}" | tr -d :)
+            ;;
+            '  - '*)
+                if [ -z "${dependencies}" ]; then
+                    dependencies=${name}
+                else
+                    dependencies=${dependencies}'\n'${name}
+                fi
+            ;;
+            '    - '*)
+                dependencies=${dependencies}'\n'${dep_provider}'.'${name}
+            ;;
+        esac
+    done <"${file}"
+
+    printf "$dependencies" | sort | cksum | cut -f 1 -d ' '
+}
+
+conda_file="conda.yaml"
+
+if [ ! -f "${conda_file}" ]; then
+    echo "${conda_file} not found in $(pwd)"
+    exit 1
+fi
+
+registry=${FUSEML_REGISTRY:-"registry.fuseml-registry"}
+repository=${FUSEML_REPOSITORY:-"mlflow/trainer"}
+tag=$(get_tag)
+
+# destination is the task output, when using the internal FuseML registry we need to reference the repository
+# using the localhost address (see https://github.com/fuseml/fuseml/issues/65).
+destination="${FUSEML_REGISTRY:-127.0.0.1:30500}/${repository}:${tag}"
+
+if docker-ls tags ${repository} -r http://${registry} -j | jq -re ".tags | index(\"${tag}\")" &>/dev/null; then
+    echo "${repository}:${tag} already exists, not building"
+else
+    echo "${repository}:${tag} not found in ${registry}, building..."
+    mkdir -p .fuseml
+    cp -r ${MLFLOW_DOCKERFILE}/* .fuseml/
+
+    /kaniko/executor --insecure --dockerfile=.fuseml/Dockerfile  --context=./ --destination=${registry}/${repository}:${tag}
+fi
+
+printf ${destination} > /tekton/results/${TASK_RESULT}


### PR DESCRIPTION
Currently the mlflow builder is being used just as a means for providing
the Dockerfile to build the trainer image.

This change updates the mlflow builder to also build the trainer image,
besides, it also checks if an image with the same dependencies already
exists on the registry and in that case skips building the image allowing
previsouly built images to be reused.

Fixes: fuseml/fuseml#162
Partially fixes: fuseml/fuseml#59