### PR TITLE
mlflow-builder: use upstream miniconda3 image as base

### DIFF
--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -1,14 +1,24 @@
+FROM continuumio/miniconda3:4.9.2-alpine
 
-FROM ghcr.io/fuseml/mlflow:1.14.1
+RUN apk add --no-cache bash git
 
 COPY conda.yaml /env/
-RUN env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
-	sed -i "s/base/$env/" /root/.bashrc
 
+RUN env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
+   printf ". /opt/conda/etc/profile.d/conda.sh\nconda activate ${env}" > /root/.bashrc
+
+ENV PIP_NO_CACHE_DIR=off
 ENV BASH_ENV /root/.bashrc
-RUN conda env create -f /env/conda.yaml
+
+RUN conda update conda && \
+  conda env create -f /env/conda.yaml && \
+  find /opt/conda/ -follow -type f -name '*.a' -delete && \
+  find /opt/conda/ -follow -type f -name '*.js.map' -delete && \
+  conda clean -afy
 
 COPY .fuseml/run.sh /usr/local/bin/run
 
+WORKDIR /workspace
+
 CMD [ "run" ]
-	
+

--- a/images/builders/mlflow/mlflow/run.sh
+++ b/images/builders/mlflow/mlflow/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 set -u
@@ -17,3 +17,4 @@ model_uri="$(mlflow runs describe --run-id ${run_id} | grep -oEm1 's3.*artifacts
 if [ -n "$TASK_RESULT" ]; then
     printf "${model_uri}" > /tekton/results/${TASK_RESULT}
 fi
+


### PR DESCRIPTION
Instead of using the mlflow image as base, use the upstream miniconda3
image which is smaller in size. Besides that, also performs a better
cleaning after installing the requirements into the trainer image.