### PR TITLE
mlflow-builder: update miniconda3 base image

### DIFF
--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -1,6 +1,4 @@
-FROM continuumio/miniconda3:4.9.2-alpine
-
-RUN apk add --no-cache bash git
+FROM continuumio/miniconda3:4.10.3-alpine
 
 COPY conda.yaml /env/
 


### PR DESCRIPTION
Update the base image used for building the trainer image for mlflow.
Also, removes the installation of bash and git from the Dockerfile as
they are now part of the base image.