### PR TITLE
Define cert-manager as a fuseml-extension

### DIFF
--- a/installer/cert-manager/description.yaml
+++ b/installer/cert-manager/description.yaml
@@ -1,0 +1,12 @@
+name: cert-manager
+description: |
+  Automatically provision and manage TLS certificates in Kubernetes
+namespace:
+install:
+  - type: manifest
+    location: https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml
+  - type: script
+    location: wait-until-available.sh
+uninstall:
+  - type: manifest
+    location: https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml

--- a/installer/cert-manager/wait-until-available.sh
+++ b/installer/cert-manager/wait-until-available.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+kubectl wait --for=condition=available --timeout=600s deployment/cert-manager-webhook -n cert-manager


### PR DESCRIPTION
cert-manager.yaml downloaded from
https://github.com/jetstack/cert-manager/releases/download/v1.4.0/cert-manager.yaml