### PR TITLE
fix for mlflow extension description

### DIFF
--- a/installer/mlflow/description.yaml
+++ b/installer/mlflow/description.yaml
@@ -1,12 +1,11 @@
 name: mlflow
 description: |
   MLFlow is an open source platform specialized in tracking ML experiments, and packaging and deploying ML models.
-namespace: fuseml-workloads
 install:
   - type: helm
     location: https://github.com/fuseml/extensions/raw/main/charts/mlflow-0.0.1.tgz
+    namespace: fuseml-workloads
     values:
-    waitfor: pods
 uninstall:
   - type: helm
 gateways:


### PR DESCRIPTION
- namespace must be per step, otherwise is considered empty
- wait for pods is not necessary, helm chart is installed with --wait