### PR TITLE
kfserving: make overlay compatible with kustomize v3+

### DIFF
--- a/installer/kfserving/kustomize/overlay/config-map.yaml
+++ b/installer/kfserving/kustomize/overlay/config-map.yaml
@@ -2,5 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kfserving-models-web-app-config-9kkt28dhgb
+  namespace: kfserving-system
 data:
   APP_PREFIX: /

--- a/installer/kfserving/kustomize/overlay/virtual-service.yaml
+++ b/installer/kfserving/kustomize/overlay/virtual-service.yaml
@@ -2,6 +2,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: kfserving-models-web-app
+  namespace: kfserving-system
 spec:
   http:
     - match:


### PR DESCRIPTION
Add namespace to overlays so the kustomize patching works with
kubectl 1.21+ (see: https://github.com/kubernetes-sigs/kustomize/issues/1351)