### PR TITLE
[0.1] mlflow-builder: add support for container image updates

### DIFF
--- a/images/builders/mlflow/Dockerfile
+++ b/images/builders/mlflow/Dockerfile
@@ -23,4 +23,8 @@ ENV MLFLOW_DOCKERFILE=/fuseml-mlflow
 COPY mlflow/ ${MLFLOW_DOCKERFILE}/
 COPY run.sh /usr/local/bin/run
 
+# inject a value that is unique for every version of the built container image,
+# to use it to reset the conda dependencies cache between image updates
+RUN date +"%Y-%m-%d_%H-%M-%S" > /build-timestamp.txt
+
 ENTRYPOINT ["run"]

--- a/images/builders/mlflow/run.sh
+++ b/images/builders/mlflow/run.sh
@@ -26,7 +26,8 @@ get_tag() {
         esac
     done <"${file}"
 
-    printf "$dependencies" | sort | cksum | cut -f 1 -d ' '
+    # insert the date to allow new container image versions to invalidate previously built builder containers
+    printf "$(cat /build-timestamp.txt)$dependencies" | sort | cksum | cut -f 1 -d ' '
 }
 
 conda_file="conda.yaml"


### PR DESCRIPTION
Randomize the hash built from the conda dependencies so that every
builder container image update generates a new hash. This triggers
a rebuild of the mlflow environment container image whenever the
builder container image is updated, that otherwise would have no
effect.

Backports: #24 