### PR TITLE
[0.2] mlflow: install in own namespace

### DIFF
--- a/images/inference-services/kfserving/run.sh
+++ b/images/inference-services/kfserving/run.sh
@@ -13,8 +13,10 @@ else
     export ORG=$(tr -dc a-z0-9 </dev/urandom | head -c 6 ; echo '')
     export PROJECT=$(tr -dc a-z0-9 </dev/urandom | head -c 6 ; echo '')
 fi
+export S3_ENDPOINT=${MLFLOW_S3_ENDPOINT_URL/*:\/\//}
 
-mc alias set minio http://mlflow-minio:9000 ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY}
+
+mc alias set minio ${MLFLOW_S3_ENDPOINT_URL} ${AWS_ACCESS_KEY_ID} ${AWS_SECRET_ACCESS_KEY}
 model_bucket="minio${FUSEML_MODEL//s3:\//}"
 
 export PROTOCOL_VERSION="v1"

--- a/images/inference-services/kfserving/template.sh
+++ b/images/inference-services/kfserving/template.sh
@@ -4,7 +4,7 @@ kind: Secret
 metadata:
   name: "${ORG}-${PROJECT}-storage"
   annotations:
-     serving.kubeflow.org/s3-endpoint: mlflow-minio:9000
+     serving.kubeflow.org/s3-endpoint: ${S3_ENDPOINT}
      serving.kubeflow.org/s3-usehttps: "0"
 type: Opaque
 stringData:

--- a/installer/mlflow/description.yaml
+++ b/installer/mlflow/description.yaml
@@ -3,7 +3,7 @@ product: mlflow
 version: "1.19.0"
 description: |
   MLFlow is an open source platform specialized in tracking ML experiments, and packaging and deploying ML models.
-namespace: fuseml-workloads
+namespace: mlflow
 install:
   - type: helm
     location: https://github.com/fuseml/extensions/raw/release-0.2/charts/mlflow-0.0.1.tgz
@@ -24,20 +24,20 @@ services:
     description: MLFlow experiment tracking service API and UI
     authrequired: False
     endpoints:
-      - url: http://mlflow
+      - url: http://mlflow.mlflow
         type: internal
         configuration:
-          MLFLOW_TRACKING_URI: http://mlflow
+          MLFLOW_TRACKING_URI: http://mlflow.mlflow
   - id: mlflow-store
     resource: s3
     category: model-store
     description: MLFlow minio S3 storage back-end
     authrequired: True
     endpoints:
-      - url: http://mlflow-minio:9000
+      - url: http://mlflow-minio.mlflow:9000
         type: internal
         configuration:
-          MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio:9000
+          MLFLOW_S3_ENDPOINT_URL: http://mlflow-minio.mlflow:9000
     credentials:
       - id: default-s3-account
 servicecredentials:
@@ -47,9 +47,9 @@ servicecredentials:
         transform:
           - configvalue: AWS_ACCESS_KEY_ID
             secret: mlflow-minio
-            namespace: fuseml-workloads
+            namespace: mlflow
             secretvalue: accesskey
           - configvalue: AWS_SECRET_ACCESS_KEY
             secret: mlflow-minio
-            namespace: fuseml-workloads
+            namespace: mlflow
             secretvalue: secretkey


### PR DESCRIPTION
Complete the decoupling of MLFlow as an extension from the fuseml-core
and the workflows by parameterizing its location everywhere it is
being referenced. This also allows MLFlow to be installed in its
own namespace, similarly to any other 3rd party AI/ML tool acting
as a FuseML extension.

Backports: #26 