### PR TITLE
Update the extension descriptions with a role rules

### DIFF
--- a/installer/kfserving/description.yaml
+++ b/installer/kfserving/description.yaml
@@ -32,4 +32,14 @@ gateways:
     namespace: kfserving-system
     servicehost: kfserving-models-web-app
     port: 80
-
+rolerules:
+  - apigroups:
+      - serving.kubeflow.org
+    resources:
+      - inferenceservices
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch

--- a/installer/ovms/description.yaml
+++ b/installer/ovms/description.yaml
@@ -30,3 +30,30 @@ gateways:
     namespace: fuseml-workloads
     hostprefix: "*.ovms"
     port: 80
+rolerules:
+  - apigroups:
+      - intel.com
+    resources:
+      - ovms
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch
+  - apigroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get
+  - apigroups:
+      - networking.istio.io
+    resources:
+      - virtualservices
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch

--- a/installer/seldon-core/description.yaml
+++ b/installer/seldon-core/description.yaml
@@ -23,3 +23,20 @@ gateways:
     namespace: fuseml-workloads
     hostprefix: "*.seldon"
     port: 80
+rolerules:
+  - apigroups:
+      - machinelearning.seldon.io
+    resources:
+      - seldondeployments
+    verbs:
+      - get
+      - list
+      - create
+      - patch
+      - watch
+  - apigroups:
+      - networking.istio.io
+    resources:
+      - gateways
+    verbs:
+      - get


### PR DESCRIPTION
Workflow role that is running the prediction image needs specific
rules for each image. So let's make these rules part of extension
description so that the role can be updated every time new extension
is installed.

See https://github.com/fuseml/fuseml/issues/247