### PR TITLE
mlflow-builder: use miniconda image based on debian

### DIFF
--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -1,12 +1,11 @@
-FROM continuumio/miniconda3:4.10.3-alpine
+FROM continuumio/miniconda3:4.10.3
 
 COPY conda.yaml /env/
 
 ENV PIP_NO_CACHE_DIR=off
 ENV BASH_ENV /root/.bashrc
 
-RUN apk add -q --no-cache git && \
-  env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
+RUN env=$(awk '/name:/ {print $2}' /env/conda.yaml) && \
   printf ". /opt/conda/etc/profile.d/conda.sh\nconda activate ${env}" > /root/.bashrc && \
   conda env create -f /env/conda.yaml && \
   conda install -n ${env} boto3 && \


### PR DESCRIPTION
The current base image used to build the trainer image is based on
alpine, which does not support glibc compiled libraries. This commit
hanges the base image to use a miniconda image that is based on Debian
instead. Also, removes the installation of git as it is already
included on the image.

Fixes: https://github.com/fuseml/fuseml/issues/262