### PR TITLE
ovms: Add a pod selector to the WaitStep

### DIFF
--- a/installer/ovms/description.yaml
+++ b/installer/ovms/description.yaml
@@ -8,7 +8,7 @@ install:
     location: kustomize
     waitfor:
       - namespace: ovms-operator-system
-        selector: all
+        selector: control-plane=controller-manager
       - kind: deployment
         selector: control-plane=controller-manager
         namespace: ovms-operator-system


### PR DESCRIPTION
If a pod selector is present, fuseml-installer can wait for
pods to exist before checking their state. This prevents possible
installation failures when the state of a pod is checked while the
pod is not created yet.