### PR TITLE
knative+kfserving: Add selectors to Pods

### DIFF
--- a/installer/kfserving/description.yaml
+++ b/installer/kfserving/description.yaml
@@ -11,7 +11,9 @@ install:
     location: kustomize
     waitfor:
       - namespace: kfserving-system
-        selector: all
+        selector: control-plane=kfserving-controller-manager
+      - namespace: kfserving-system
+        selector: app.kubernetes.io/component=kfserving-models-web-app
 uninstall:
   - type: kustomize
     location: kustomize

--- a/installer/knative/description.yaml
+++ b/installer/knative/description.yaml
@@ -12,7 +12,7 @@ install:
     namespace: knative-serving
     waitfor:
       - namespace: knative-serving
-        selector: all
+        selector: serving.knative.dev/release=v0.24.0
   - type: manifest
     location: https://github.com/knative-sandbox/net-istio/releases/download/v0.24.0/release.yaml
     waitfor:


### PR DESCRIPTION
With selectors present, fuseml-installer is able to wait for Pods
existence before checking for their status.

See also: https://github.com/fuseml/fuseml/pull/279 and https://github.com/fuseml/extensions/pull/52