### PR TITLE
OVMS predictor: model prediction type as step parameter

### DIFF
--- a/images/inference-services/ovms/Dockerfile
+++ b/images/inference-services/ovms/Dockerfile
@@ -9,6 +9,7 @@ ENV S3_ENDPOINT ""
 ENV FUSEML_MODEL ""
 ENV FUSEML_MODEL_NAME default
 ENV FUSEML_OVMS_IMAGE_TAG "2021.4.1"
+ENV FUSEML_PREDICTION_TYPE "predict"
 
 RUN mkdir /opt/openvino/
 COPY run.sh /usr/local/bin/run

--- a/images/inference-services/ovms/run.sh
+++ b/images/inference-services/ovms/run.sh
@@ -80,7 +80,7 @@ kubectl wait --for=condition=Available=true --timeout=30s \
   "deploy/ovms-${APP_NAME}" -n "${FUSEML_ENV_WORKFLOW_NAMESPACE}"
 kubectl rollout status "deploy/ovms-${APP_NAME}" -n "${FUSEML_ENV_WORKFLOW_NAMESPACE}" --timeout=2m
 
-prediction_url="http://${ISTIO_HOST}/v1/models/${FUSEML_MODEL_NAME}"
+prediction_url="http://${ISTIO_HOST}/v1/models/${FUSEML_MODEL_NAME}:${FUSEML_PREDICTION_TYPE}"
 
 echo "${prediction_url}" > "/tekton/results/${TASK_RESULT}"
 


### PR DESCRIPTION
The prediction operation type featured by the TensorFlow API [1]
and reflected in the prediction URLs can take one of the `classify`,
`regress` or `predict` values.
It's too difficult to determine from the model which of these
operations are applicable to a given model, so we're modelling it as
a step parameter instead.

[1] https://www.tensorflow.org/tfx/serving/api_rest