### PR TITLE
Adapt the builder process for different kind of requirements

### DIFF
--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -1,4 +1,7 @@
-FROM continuumio/miniconda3:4.10.3
+ARG MINICONDA_VERSION=4.10.3
+ARG BASE_IMAGE=continuumio/miniconda3:${MINICONDA_VERSION}
+
+FROM ${BASE_IMAGE}
 
 COPY conda.yaml /env/
 
@@ -18,4 +21,3 @@ COPY .fuseml/run.sh /usr/local/bin/run
 WORKDIR /workspace
 
 CMD [ "run" ]
-


### PR DESCRIPTION
Based on the codeset content, builder image now chooses how to build
the trainer image, either using conda.yaml or requirements.txt file.

Additionally provide way to specify base image version. Some specific ML
dependencies are not available in the latest conda image so let user
have a chance to specify version of conda base image in the workflow file.