### PR TITLE
Adapt the builder so it can prepare Intel optimized trainer images

### DIFF
--- a/images/builders/mlflow/mlflow/Dockerfile
+++ b/images/builders/mlflow/mlflow/Dockerfile
@@ -1,17 +1,28 @@
+ARG BASE=conda
 ARG MINICONDA_VERSION=4.10.3
 ARG CONDA_BASE_IMAGE=continuumio/miniconda3:${MINICONDA_VERSION}
-ARG BASE=conda
-ARG BASE_IMAGE=intel/intel-optimized-tensorflow:latest
+ARG INTEL_BASE_IMAGE=intel/intel-optimized-tensorflow:latest
+ARG BASE_IMAGE=python:3.6.13
 
 # intel based image needs to pip install from requirements.txt
 # (because it has some requirements preinstalled with pip already)
+FROM ${INTEL_BASE_IMAGE} as intel
+
+ENV PIP_NO_CACHE_DIR=off
+
+ONBUILD COPY requirements.txt /
+ONBUILD RUN apt-get update && apt-get -y install git && \
+    pip install --upgrade pip && pip install -r requirements.txt
+
+
+# generic image with pip
 FROM ${BASE_IMAGE} as requirements
 
 ENV PIP_NO_CACHE_DIR=off
 
 ONBUILD COPY requirements.txt /
-ONBUILD RUN pip install --upgrade pip && pip install -r requirements.txt
-ONBUILD RUN apt-get update && apt-get -y install git
+ONBUILD RUN apt-get update && apt-get -y install git && \
+    pip install --upgrade pip && pip install -r requirements.txt
 
 # conda based image
 FROM ${CONDA_BASE_IMAGE} as conda

--- a/images/builders/mlflow/run.sh
+++ b/images/builders/mlflow/run.sh
@@ -40,11 +40,15 @@ repository=${FUSEML_REPOSITORY:-"mlflow/trainer"}
 if [ -n "${FUSEML_MINICONDA_VERSION}" ]; then
     BUILDARGS="$BUILDARGS --build-arg MINICONDA_VERSION=$FUSEML_MINICONDA_VERSION"
 fi
-if [ -n "${FUSEML_BASE_IMAGE}" ]; then
-    BUILDARGS="$BUILDARGS --build-arg BASE_IMAGE=$FUSEML_BASE_IMAGE"
-fi
 if [ -n "${FUSEML_INTEL_OPTIMIZED}" ]; then
-    BUILDARGS="$BUILDARGS --build-arg BASE=requirements"
+    BUILDARGS="$BUILDARGS --build-arg BASE=intel"
+fi
+if [ -n "${FUSEML_BASE_IMAGE}" ]; then
+    if [ -n "${FUSEML_INTEL_OPTIMIZED}" ]; then
+        BUILDARGS="$BUILDARGS --build-arg INTEL_BASE_IMAGE=$FUSEML_BASE_IMAGE"
+    else
+        BUILDARGS="$BUILDARGS --build-arg BASE_IMAGE=$FUSEML_BASE_IMAGE"
+    fi
 fi
 
 if [ ! -f "conda.yaml" ]; then
@@ -52,7 +56,9 @@ if [ ! -f "conda.yaml" ]; then
         echo "Neither conda.yaml not requirements.txt found in $(pwd)"
         exit 1
     fi
-    BUILDARGS="$BUILDARGS --build-arg BASE=requirements"
+    if [ -z "${FUSEML_INTEL_OPTIMIZED}" ]; then
+        BUILDARGS="$BUILDARGS --build-arg BASE=requirements"
+    fi
     # prepare conda.yaml based on existing requirements.txt
     # (this generated conda.yaml will only be used for tag generation not for the installation)
     cat > conda.yaml << EOF


### PR DESCRIPTION
With INTEL_OPTIMIZED set in the workflow inputs, the trainer image
will use intel/intel-optimized-tensorflow image as a base.

It is further possible to specify base image with INTEL_BASE_IMAGE
used as another the workflow input value, otherwise
intel/intel-optimized-tensorflow:latest will be used as a default.