### PR TITLE
Include workflow name in the resources identification

### DIFF
--- a/images/inference-services/kfserving/run.sh
+++ b/images/inference-services/kfserving/run.sh
@@ -34,7 +34,7 @@ if [ "${PREDICTOR}" = "auto" ]; then
     fi
 fi
 
-isvc="${ORG}-${PROJECT}"
+export isvc="${ORG}-${PROJECT}-${FUSEML_ENV_WORKFLOW_NAME}"
 case $PREDICTOR in
     # kfserving expects the tensorflow model to be under a numbered directory,
     # however mlflow saves the model under 'tfmodel', so if there is no directory

--- a/images/inference-services/kfserving/template.sh
+++ b/images/inference-services/kfserving/template.sh
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "${ORG}-${PROJECT}-storage"
+  name: "${isvc}-storage"
   annotations:
      serving.kubeflow.org/s3-endpoint: ${S3_ENDPOINT}
      serving.kubeflow.org/s3-usehttps: "0"
@@ -14,21 +14,22 @@ stringData:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "${ORG}-${PROJECT}-kfserving"
+  name: "${isvc}-kfserving"
 secrets:
-  - name: "${ORG}-${PROJECT}-storage"
+  - name: "${isvc}-storage"
 ---
 apiVersion: "serving.kubeflow.org/v1beta1"
 kind: "InferenceService"
 metadata:
-  name: "${ORG}-${PROJECT}"
+  name: "${isvc}"
   labels:
     fuseml/app-name: "${PROJECT}"
     fuseml/org: "${ORG}"
-    fuseml/app-guid: "${ORG}.${PROJECT}"
+    fuseml/workflow: "${FUSEML_ENV_WORKFLOW_NAME}"
+    fuseml/app-guid: "${ORG}.${PROJECT}.${FUSEML_ENV_WORKFLOW_NAME}"
 spec:
   predictor:
-    serviceAccountName: "${ORG}-${PROJECT}-kfserving"
+    serviceAccountName: "${isvc}-kfserving"
     timeout: 60
     ${PREDICTOR}:
       protocolVersion: ${PROTOCOL_VERSION}

--- a/images/inference-services/ovms/run.sh
+++ b/images/inference-services/ovms/run.sh
@@ -24,7 +24,7 @@ OVMS_ISTIO_GATEWAY=ovms-gateway
 # host wildcard configured in the form of '*.<domain>'
 DOMAIN=$(kubectl get Gateway ${OVMS_ISTIO_GATEWAY} -n ${NAMESPACE} -o jsonpath='{.spec.servers[0].hosts[0]}')
 ISTIO_HOST="${ORG}.${PROJECT}${DOMAIN/\*/}"
-APP_NAME="${ORG}-${PROJECT}"
+APP_NAME="${ORG}-${PROJECT}-${FUSEML_ENV_WORKFLOW_NAME}"
 
 cat << EOF > /opt/openvino/templates/values.yaml
 #@data/values

--- a/images/inference-services/seldon-core/run.sh
+++ b/images/inference-services/seldon-core/run.sh
@@ -29,7 +29,7 @@ if [ "${PREDICTOR}" = "auto" ]; then
     PREDICTOR=$(mc cat ${model_bucket}/MLmodel | awk -F '.' '/loader_module:/ {print $2}')
 fi
 
-sd="${ORG}-${PROJECT}"
+export sd="${ORG}-${PROJECT}-${FUSEML_ENV_WORKFLOW_NAME}"
 case $PREDICTOR in
     sklearn)
         if ! mc ls ${model_bucket} | grep -q "model.joblib"; then

--- a/images/inference-services/seldon-core/template.sh
+++ b/images/inference-services/seldon-core/template.sh
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: "${ORG}-${PROJECT}-init-container-secret"
+  name: "${sd}-init-container-secret"
   annotations:
      serving.kubeflow.org/s3-endpoint: mlflow-minio:9000
      serving.kubeflow.org/s3-usehttps: "0"
@@ -18,38 +18,40 @@ stringData:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: "${ORG}-${PROJECT}-seldon"
+  name: "${sd}-seldon"
 secrets:
-  - name: "${ORG}-${PROJECT}-init-container-secret"
+  - name: "${sd}-init-container-secret"
 ---
 apiVersion: "machinelearning.seldon.io/v1alpha2"
 kind: "SeldonDeployment"
 metadata:
-  name: "${ORG}-${PROJECT}"
+  name: "${sd}"
   labels:
     fuseml/app-name: "${PROJECT}"
     fuseml/org: "${ORG}"
-    fuseml/app-guid: "${ORG}.${PROJECT}"
+    fuseml/workflow: "${FUSEML_ENV_WORKFLOW_NAME}"
+    fuseml/app-guid: "${ORG}.${PROJECT}.${FUSEML_ENV_WORKFLOW_NAME}"
   annotations:
     "seldon.io/istio-host": "${ISTIO_HOST}"
     "seldon.io/istio-gateway": "${FUSEML_ENV_WORKFLOW_NAMESPACE}/seldon-gateway"
 spec:
-  name: "${ORG}-${PROJECT}"
+  name: "${sd}"
   protocol: "${PROTOCOL}"
   predictors:
     - name: "predictor"
       labels:
         fuseml/app-name: "${PROJECT}"
         fuseml/org: "${ORG}"
-        fuseml/app-guid: "${ORG}.${PROJECT}"
+        fuseml/workflow: "${FUSEML_ENV_WORKFLOW_NAME}"
+        fuseml/app-guid: "${ORG}.${PROJECT}.${FUSEML_ENV_WORKFLOW_NAME}"
       replicas: 1
       graph:
         children: []
         implementation: "${PREDICTOR_SERVER}"
         modelUri: "${FUSEML_MODEL}"
-        envSecretRefName: "${ORG}-${PROJECT}-init-container-secret"
+        envSecretRefName: "${sd}-init-container-secret"
         name: classifier
-        serviceAccountName: "${ORG}-${PROJECT}-seldon"
+        serviceAccountName: "${sd}-seldon"
         parameters: ${PARAMETERS}
       componentSpecs:
         - spec:


### PR DESCRIPTION
When creating specific K8S and FuseML resources for inference services,
use the workflow name as part of the identification.

This way, when a codeset is run with different workflows, new resources
are created for each codeset-workflow combination instead of relying on
codeset information only, thus being recreated with the same name.