### PR TITLE
Use 'latest' tag for images built in main branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           case "${GITHUB_REF}" in
             refs/heads/main)
-              TAG="dev"
+              TAG="latest"
               ;;
             refs/tags/v*)
               TAG=${GITHUB_REF/refs\/tags\//}

--- a/images/Makefile
+++ b/images/Makefile
@@ -15,9 +15,9 @@ GIT_REF = $(shell git symbolic-ref -q --short HEAD || git describe --tags --abbr
 ifdef VERSION
 	IMAGE_TAG = $(VERSION)
 else
-# Use `dev` as a default version value when compiling in the main branch
+# Use `latest` as a default version value when compiling in the main branch
 ifeq ($(GIT_REF),main)
-	IMAGE_TAG = dev
+	IMAGE_TAG = latest
 # Use the reference name as a default version value when compiling in another branch/tag,
 else
 	IMAGE_TAG = $(GIT_REF)


### PR DESCRIPTION
The current `dev` tags often result in cached and outdated images
being used during development when running workflows. To make the
development process simpler and to ensure that local testing always
uses the latest development images, the `latest` tag should be used
instead, to force Tekton to always refresh the local k8s image cache,
if newer images are available in the remote registry.