### PR TITLE
Knative: Retry patching config map

### DIFF
--- a/installer/knative/patch-knative-domain.sh
+++ b/installer/knative/patch-knative-domain.sh
@@ -15,6 +15,17 @@ if [ -z "$ISTIO_DOMAIN" ]; then
   fi
 fi
 
-kubectl -n knative-serving patch configmap config-domain --type merge \
-  -p "{\"data\":{\"$ISTIO_DOMAIN\":\"\"}}"
+
+# Patch the Knative config with the domain. Retries 5 times with a 3s delay between each attempt,
+# as the net-istio config validation webhook might not be ready yet.
+retries=0
+until [ "$retries" -ge 5 ]
+do
+   kubectl -n knative-serving patch configmap config-domain --type merge \
+    -p "{\"data\":{\"$ISTIO_DOMAIN\":\"\"}}" && break
+   retries=$((retries+1)) 
+   sleep 3
+done
+
+
 


### PR DESCRIPTION
CI is sometimes failing when running the `patch-knative-domain.sh`
as the net-istio-webhook seems to not be ready. This change adds
retries to the kubectl command so it can retry in case of failure.