### PR TITLE
[0.3] Document workflow extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 This repository contains FuseML extensions
 
-`installer` directory contains descriptions defining how to install extensions by FuseML installer
+- the `installer` directory is the default extension repository used by the FuseML installer. It contains descriptions for extensions for 3rd party tools that can be installed by the FuseML installer.
 
-`images` directory contains various extension images used by FuseML workflows
+- the `images` directory contains various [extension images that can be used as FuseML workflow steps](images/)
 
-`charts` directory contains helm charts of FuseML extensions
+- the `charts` directory contains helm charts of FuseML extensions

--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,8 @@
+# FuseML Workflow Extensions
+
+This folder contains a set of container images implementing various FuseML workflow steps maintained by the FuseML team:
+
+- [MLFlow builder](builders/mlflow/) - builds python runtime environment container images for codesets that are structured according to the [MLFlow Project format](https://www.mlflow.org/docs/latest/projects.html).
+- [KServe predictor](inference-services/kserve/) - deploys models using the [KServe inference platform](https://kserve.github.io/website/).
+- [Seldon Core predictor](inference-services/seldon-core/) - deploys ML models using the [Seldon Core MLOps platform](https://docs.seldon.io/projects/seldon-core/en/latest/).
+- [OVMS converter](converters/ovms/) and [predictor](inference-services/ovms/) - can be used to optimize and convert ML models into the Intel IR format with the [OpenVINO Model Optimizer](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html) and then deploy them using the [OpenVINO Model Server](https://docs.openvino.ai/latest/openvino_docs_ovms.html).

--- a/images/builders/mlflow/README.md
+++ b/images/builders/mlflow/README.md
@@ -2,4 +2,4 @@
 
 The Dockerfile and associated files in this folder implement the FuseML MLflow builder workflow step. The container image is based on [Kaniko](https://github.com/GoogleContainerTools/kaniko) and leverages the MLflow Project conventions to automate building MLflow runtime environments: container images used for the execution of MLflow augmented python code within a FuseML workflow.
 
-For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/mlflow-builder/).
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/v0.3/workflows/mlflow-builder/).

--- a/images/builders/mlflow/README.md
+++ b/images/builders/mlflow/README.md
@@ -1,0 +1,5 @@
+# MLflow python environment builder component for FuseML workflows
+
+The Dockerfile and associated files in this folder implement the FuseML MLflow builder workflow step. The container image is based on [Kaniko](https://github.com/GoogleContainerTools/kaniko) and leverages the MLflow Project conventions to automate building MLflow runtime environments: container images used for the execution of MLflow augmented python code within a FuseML workflow.
+
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/mlflow-builder/).

--- a/images/converters/ovms/README.md
+++ b/images/converters/ovms/README.md
@@ -1,0 +1,5 @@
+# OpenVINO Model Server converter extension for FuseML workflows
+
+The Dockerfile and associated files in this folder implement the FuseML OVMS converter workflow step. The OVMS converter workflow step can be used to convert input ML models to the IR (Intermediate Representation) format supported by the [OpenVINO Model Server](https://docs.openvino.ai/latest/openvino_docs_ovms.html). It is normally used in combination with the [OVMS predictor workflow step](../../inference-services/ovms/) in FuseML workflows to serve input ML models with the OpenVINO Model Server. The OVMS converter workflow extension is implemented using the [OpenVINO Model Optimizer](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
+
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/ovms-converter/).

--- a/images/converters/ovms/README.md
+++ b/images/converters/ovms/README.md
@@ -2,4 +2,4 @@
 
 The Dockerfile and associated files in this folder implement the FuseML OVMS converter workflow step. The OVMS converter workflow step can be used to convert input ML models to the IR (Intermediate Representation) format supported by the [OpenVINO Model Server](https://docs.openvino.ai/latest/openvino_docs_ovms.html). It is normally used in combination with the [OVMS predictor workflow step](../../inference-services/ovms/) in FuseML workflows to serve input ML models with the OpenVINO Model Server. The OVMS converter workflow extension is implemented using the [OpenVINO Model Optimizer](https://docs.openvino.ai/latest/openvino_docs_MO_DG_Deep_Learning_Model_Optimizer_DevGuide.html).
 
-For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/ovms-converter/).
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/v0.3/workflows/ovms-converter/).

--- a/images/inference-services/kserve/README.md
+++ b/images/inference-services/kserve/README.md
@@ -1,0 +1,5 @@
+# KServe predictor extension for FuseML workflows
+
+The Dockerfile and associated files in this folder implement the FuseML KServe predictor workflow step. The KServe predictor can be used to create and manage [KServe prediction services](https://kserve.github.io/website/) to serve input ML models as part of the execution of FuseML workflows.
+
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/kserve-predictor/).

--- a/images/inference-services/kserve/README.md
+++ b/images/inference-services/kserve/README.md
@@ -2,4 +2,4 @@
 
 The Dockerfile and associated files in this folder implement the FuseML KServe predictor workflow step. The KServe predictor can be used to create and manage [KServe prediction services](https://kserve.github.io/website/) to serve input ML models as part of the execution of FuseML workflows.
 
-For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/kserve-predictor/).
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/v0.3/workflows/kserve-predictor/).

--- a/images/inference-services/ovms/README.md
+++ b/images/inference-services/ovms/README.md
@@ -1,0 +1,5 @@
+# OpenVINO Model Server predictor extension for FuseML workflows
+
+The Dockerfile and associated files in this folder implement the FuseML OVMS predictor workflow step. The OVMS predictor can be used to create and manage [OpenVINO Model Server inference servers](https://docs.openvino.ai/latest/openvino_docs_ovms.html) to serve input ML models as part of the execution of FuseML workflows. The OVMS predictor only accepts models in IR (Intermediate Representation) format as input. The [OVMS converter](../../converters/ovms/) workflow extension can be used to convert models to IR format.
+
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/ovms-predictor/).

--- a/images/inference-services/ovms/README.md
+++ b/images/inference-services/ovms/README.md
@@ -2,4 +2,4 @@
 
 The Dockerfile and associated files in this folder implement the FuseML OVMS predictor workflow step. The OVMS predictor can be used to create and manage [OpenVINO Model Server inference servers](https://docs.openvino.ai/latest/openvino_docs_ovms.html) to serve input ML models as part of the execution of FuseML workflows. The OVMS predictor only accepts models in IR (Intermediate Representation) format as input. The [OVMS converter](../../converters/ovms/) workflow extension can be used to convert models to IR format.
 
-For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/ovms-predictor/).
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/v0.3/workflows/ovms-predictor/).

--- a/images/inference-services/seldon-core/README.md
+++ b/images/inference-services/seldon-core/README.md
@@ -1,0 +1,5 @@
+# Seldon Core predictor extension for FuseML workflows
+
+The Dockerfile and associated files in this folder implement the FuseML Seldon Core predictor workflow step. The Seldon Core predictor can be used to create and manage [Seldon Core prediction services](https://docs.seldon.io/projects/seldon-core/en/latest/) to serve input ML models as part of the execution of FuseML workflows.
+
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/seldon-core-predictor/).

--- a/images/inference-services/seldon-core/README.md
+++ b/images/inference-services/seldon-core/README.md
@@ -2,4 +2,4 @@
 
 The Dockerfile and associated files in this folder implement the FuseML Seldon Core predictor workflow step. The Seldon Core predictor can be used to create and manage [Seldon Core prediction services](https://docs.seldon.io/projects/seldon-core/en/latest/) to serve input ML models as part of the execution of FuseML workflows.
 
-For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/dev/workflows/seldon-core-predictor/).
+For more information on what this workflow step does and how it can be used, see the [FuseML documentation](https://fuseml.github.io/docs/v0.3/workflows/seldon-core-predictor/).


### PR DESCRIPTION
Create a structure for more elaborated documentation covering the
available FuseML workflow extensions and pointing to the official
FuseML documentation for details.

Backport of #79 